### PR TITLE
Tom/instance selector spacing typography

### DIFF
--- a/src/modules/instance-selector/instance-item.tsx
+++ b/src/modules/instance-selector/instance-item.tsx
@@ -118,7 +118,7 @@ export function InstanceDescription({
     <div className="col flex-1 gap-2">
       <div className="row items-center gap-2 font-medium">
         <RadioInput disabled={disabled} checked={selected} onChange={onSelected} data-instance />
-        {instance.displayName}
+        <span className="text-base">{instance.displayName}</span>
         {badges}
       </div>
 

--- a/src/modules/instance-selector/instance-item.tsx
+++ b/src/modules/instance-selector/instance-item.tsx
@@ -92,7 +92,7 @@ function InstancePrice({ instance }: { instance: CatalogInstance }) {
 
       <div className="sm:hidden">{bullet}</div>
 
-      <div className="text-xs text-dim">
+      <div className="mt-1 text-xs text-dim">
         <T id="costs.pricePerMonth" values={{ price: <FormattedPrice value={instance.pricePerMonth} /> }} />
       </div>
     </div>

--- a/src/modules/instance-selector/region-selector.tsx
+++ b/src/modules/instance-selector/region-selector.tsx
@@ -29,7 +29,7 @@ export function RegionSelector({
 }: RegionSelectorProps) {
   return (
     <Collapse open={expanded}>
-      <div className="col sm:row mb-2 mt-4 items-start justify-between gap-2 sm:items-center">
+      <div className="col sm:row mb-3 mt-4 items-start justify-between gap-2 sm:items-center">
         <div className="text-dim">
           <T id="regions.label" />
         </div>
@@ -50,7 +50,7 @@ export function RegionSelector({
         )}
       </div>
 
-      <ul className="row flex-wrap justify-start gap-4">
+      <ul className="row flex-wrap justify-start gap-2">
         {regions.map((region) => (
           <li key={region.identifier} className="w-full sm:w-56">
             <RegionItem


### PR DESCRIPTION
Improve spacing and typography in instance and region selectors

- Adjusted bottom margin in the region selector container from `mb-2` to `mb-3` for better vertical spacing.
- Reduced gap between region items in the list from `gap-4` to `gap-2` to make the layout more compact.
- Added a top margin (`mt-1`) to the price per month text in the instance item for improved spacing.
- Updated the typography of the instance display name by wrapping it in a `<span>` with `text-base` class for consistent font size.