### PR TITLE
Select the region with the lowest latency

### DIFF
--- a/src/application/default-region.ts
+++ b/src/application/default-region.ts
@@ -1,20 +1,17 @@
 import { QueryClient } from '@tanstack/react-query';
 
-import { CatalogDatacenter, CatalogInstance, CatalogRegion, RegionScope } from 'src/api/model';
+import { CatalogDatacenter, CatalogInstance, CatalogRegion } from 'src/api/model';
 import { inArray } from 'src/utils/arrays';
 import { hasProperty } from 'src/utils/object';
 
 export function getDefaultRegion(
   queryClient: QueryClient,
-  datacenters: CatalogDatacenter[],
-  regions: CatalogRegion[],
+  datacenters: readonly CatalogDatacenter[],
+  regions: readonly CatalogRegion[],
   instance: CatalogInstance | undefined,
 ) {
-  const targetScope: RegionScope = instance?.category === 'gpu' ? 'continental' : 'metropolitan';
-
   const availableRegions = regions
     .filter((region) => region.status === 'available')
-    .filter((region) => region.scope === targetScope)
     .filter((region) => !region.instances || inArray(instance?.identifier, region.instances));
 
   const regionLatencies = getRegionLatencies(queryClient, datacenters, availableRegions);
@@ -28,7 +25,7 @@ export function getDefaultRegion(
   }
 }
 
-function getRegionDatacenterUrl(datacenters: CatalogDatacenter[], region: CatalogRegion) {
+function getRegionDatacenterUrl(datacenters: readonly CatalogDatacenter[], region: CatalogRegion) {
   const datacenter = datacenters.find(hasProperty('identifier', region.datacenters[0]));
 
   if (datacenter) {
@@ -38,8 +35,8 @@ function getRegionDatacenterUrl(datacenters: CatalogDatacenter[], region: Catalo
 
 function getRegionLatencies(
   queryClient: QueryClient,
-  datacenters: CatalogDatacenter[],
-  regions: CatalogRegion[],
+  datacenters: readonly CatalogDatacenter[],
+  regions: readonly CatalogRegion[],
 ) {
   const result = new Map<CatalogRegion, number>();
 

--- a/src/application/default-region.ts
+++ b/src/application/default-region.ts
@@ -1,6 +1,6 @@
 import { QueryClient } from '@tanstack/react-query';
 
-import { CatalogDatacenter, CatalogRegion } from 'src/api/model';
+import { CatalogDatacenter, CatalogInstance, CatalogRegion, RegionScope } from 'src/api/model';
 import { inArray } from 'src/utils/arrays';
 import { hasProperty } from 'src/utils/object';
 
@@ -8,12 +8,14 @@ export function getDefaultRegion(
   queryClient: QueryClient,
   datacenters: CatalogDatacenter[],
   regions: CatalogRegion[],
-  instance: string | null,
+  instance: CatalogInstance | undefined,
 ) {
+  const targetScope: RegionScope = instance?.category === 'gpu' ? 'continental' : 'metropolitan';
+
   const availableRegions = regions
     .filter((region) => region.status === 'available')
-    .filter((region) => region.scope === 'metropolitan')
-    .filter((region) => !region.instances || inArray(instance, region.instances));
+    .filter((region) => region.scope === targetScope)
+    .filter((region) => !region.instances || inArray(instance?.identifier, region.instances));
 
   const regionLatencies = getRegionLatencies(queryClient, datacenters, availableRegions);
 

--- a/src/modules/instance-selector/instance-selector-state.spec.ts
+++ b/src/modules/instance-selector/instance-selector-state.spec.ts
@@ -15,6 +15,8 @@ describe('instance selector', () => {
 
   let availabilities: Record<string, InstanceAvailability>;
 
+  let singleRegion: boolean | undefined;
+
   let state: InstanceSelectorState;
   let selector: InstanceSelector;
 
@@ -44,6 +46,8 @@ describe('instance selector', () => {
       [gpu1.identifier]: [true],
       [gpu2.identifier]: [true],
     };
+
+    singleRegion = undefined;
 
     state = {
       regionScope: 'metropolitan',
@@ -75,6 +79,7 @@ describe('instance selector', () => {
         instances: [free, ecoNano, ecoMicro, nano, micro, awsNano, gpu1, gpu2],
         regions: [fra, par, eu],
         availabilities,
+        singleRegion,
       },
       state,
       (next) => (state = next),
@@ -290,6 +295,29 @@ describe('instance selector', () => {
       act(() => selector.onRegionSelected(fra));
 
       expect(selector.selectedRegions).toEqual([]);
+    });
+
+    it('allows selecting a single region', () => {
+      setup(() => {
+        singleRegion = true;
+        setInitialRegions([fra]);
+      });
+
+      act(() => selector.onRegionSelected(par));
+
+      expect(selector.selectedRegions).toEqual([par]);
+    });
+
+    it('keeps a single region when singleRegion is enabled', () => {
+      setup(() => {
+        setInitialRegions([fra, par]);
+        setInitialInstance(nano);
+      });
+
+      act(() => (singleRegion = true));
+      act(() => selector.onInstanceCategorySelected('eco'));
+
+      expect(selector.selectedRegions).toEqual([fra]);
     });
   });
 });

--- a/src/modules/instance-selector/instance-selector-state.spec.ts
+++ b/src/modules/instance-selector/instance-selector-state.spec.ts
@@ -212,6 +212,14 @@ describe('instance selector', () => {
 
       expect(selector.selectedRegions).toEqual([fra]);
     });
+
+    it('selects a continental region when selecting a GPU', () => {
+      setup();
+
+      act(() => selector.onInstanceCategorySelected('gpu'));
+
+      expect(selector.selectedRegions).toEqual([eu]);
+    });
   });
 
   describe('region scope', () => {

--- a/src/modules/instance-selector/instance-selector-state.spec.ts
+++ b/src/modules/instance-selector/instance-selector-state.spec.ts
@@ -336,7 +336,7 @@ describe('instance selector', () => {
       act(() => (singleRegion = true));
       act(() => selector.onInstanceCategorySelected('eco'));
 
-      expect(selector.selectedRegions).toEqual([fra]);
+      expect(selector.selectedRegions).toEqual([par]);
     });
   });
 });

--- a/src/modules/instance-selector/instance-selector-state.ts
+++ b/src/modules/instance-selector/instance-selector-state.ts
@@ -6,6 +6,7 @@ import { useDatacenters } from 'src/api/hooks/catalog';
 import { CatalogInstance, CatalogRegion, InstanceCategory, RegionScope } from 'src/api/model';
 import { getDefaultRegion } from 'src/application/default-region';
 import { InstanceAvailability } from 'src/application/instance-region-availability';
+import { last } from 'src/utils/arrays';
 import { hasProperty } from 'src/utils/object';
 
 export type InstanceSelectorParams = {
@@ -163,8 +164,10 @@ export function instanceSelector(
       }
     }
 
-    if (singleRegion && nextState.selectedRegions.length >= 2) {
-      nextState.selectedRegions = [nextState.selectedRegions[0]!];
+    const isFreeInstance = nextState.selectedInstance?.identifier === 'free';
+
+    if ((singleRegion || isFreeInstance) && nextState.selectedRegions.length >= 2) {
+      nextState.selectedRegions = [last(nextState.selectedRegions)!];
     }
 
     setState(nextState);
@@ -196,11 +199,6 @@ export function instanceSelector(
 
     selectedRegions,
     onRegionSelected: (region) => {
-      if (selectedInstance?.identifier === 'free' || singleRegion) {
-        update({ selectedRegions: [region] });
-        return;
-      }
-
       const regions = selectedRegions.slice();
       const index = regions.indexOf(region);
 

--- a/src/modules/instance-selector/instance-selector-state.ts
+++ b/src/modules/instance-selector/instance-selector-state.ts
@@ -118,6 +118,10 @@ export function instanceSelector(
       }
     }
 
+    if (updates.instanceCategory === 'gpu') {
+      nextState.regionScope = 'continental';
+    }
+
     const filteredRegions = filterRegions(nextState.regionScope, nextState.selectedInstance);
 
     nextState.selectedRegions = nextState.selectedRegions.filter((region) =>

--- a/src/modules/instance-selector/instance-selector-state.ts
+++ b/src/modules/instance-selector/instance-selector-state.ts
@@ -61,7 +61,7 @@ export function useInstanceSelector({
   );
 }
 
-type InstanceSelectorState = {
+export type InstanceSelectorState = {
   instanceCategory: InstanceCategory;
   regionScope: RegionScope;
   selectedInstance: CatalogInstance | null;

--- a/src/modules/instance-selector/instance-selector-state.ts
+++ b/src/modules/instance-selector/instance-selector-state.ts
@@ -146,6 +146,10 @@ export function instanceSelector(
       }
     }
 
+    if (singleRegion && nextState.selectedRegions.length >= 2) {
+      nextState.selectedRegions = [nextState.selectedRegions[0]!];
+    }
+
     setState(nextState);
   };
 

--- a/src/modules/service-creation/steps/02-instance-region/instance-region.step.tsx
+++ b/src/modules/service-creation/steps/02-instance-region/instance-region.step.tsx
@@ -107,7 +107,12 @@ function InstanceRegionStep_({ onNext }: InstanceRegionStepProps) {
     }
 
     if (!searchParams.has('regions')) {
-      const defaultRegion = getDefaultRegion(queryClient, datacenters, regions, instance);
+      const defaultRegion = getDefaultRegion(
+        queryClient,
+        datacenters,
+        regions,
+        instances.find(hasProperty('identifier', instance)),
+      );
 
       setRegionsParam(defaultRegion ? [defaultRegion.identifier] : ['fra']);
     }

--- a/src/modules/service-form/helpers/initialize-service-form.ts
+++ b/src/modules/service-form/helpers/initialize-service-form.ts
@@ -104,7 +104,7 @@ export async function initializeServiceForm(
     }
 
     if (!params.has('regions')) {
-      const defaultRegion = getDefaultRegion(queryClient, datacenters, regions, values.instance);
+      const defaultRegion = getDefaultRegion(queryClient, datacenters, regions, instance);
 
       if (defaultRegion !== undefined) {
         values.regions = [defaultRegion.identifier];


### PR DESCRIPTION
- select the region with the lowest latency by default when changing the instance type
- select continental regions when switching from an eco / standard instance to a GPU
- refactor the instance selector logic