### PR TITLE
Fix labels in 02-builder.step (BuildpackConfiguration)

### DIFF
--- a/src/modules/service-creation/steps/02-builder/builder.step.tsx
+++ b/src/modules/service-creation/steps/02-builder/builder.step.tsx
@@ -189,8 +189,8 @@ function BuildpackConfiguration() {
     <div className="col gap-4">
       <OverridableInput<BuilderForm, 'buildpack.buildCommand'>
         name="buildpack.buildCommand"
-        label={<T id="buildpack.configuration.runCommand.label" />}
-        helpTooltip={<T id="buildpack.configuration.runCommand.tooltip" />}
+        label={<T id="buildpack.configuration.buildCommand.label" />}
+        helpTooltip={<T id="buildpack.configuration.buildCommand.tooltip" />}
       />
 
       <OverridableInput<BuilderForm, 'buildpack.runCommand'>


### PR DESCRIPTION
Noticed a typo in the BuildpackConfiguration when creating a Web Service (screenshot)
-> Input data & form works, but label and tooltip I corrected

- Tests passed
- pushed --force-with-lease

---

<img width="50%" height="1548" alt="grafik" src="https://github.com/user-attachments/assets/98fbe7ad-fd0f-46c9-b277-1f1f976d0331" />
