### PR TITLE
fix: update WorkOS root widget styles for theme-specific adjustments

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -10,7 +10,7 @@ runs:
     - name: Install Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: 20
+        node-version: 22
         cache: pnpm
 
     - name: Install dependencies

--- a/src/styles.css
+++ b/src/styles.css
@@ -106,7 +106,7 @@
 
 /* WorkOS */
 
-.woswidgets-root {
+.woswidgets-root[data-is-root-theme='true'] {
   min-height: unset;
 }
 


### PR DESCRIPTION
Fix the WorkOS widgets not showing correctly