### PR TITLE
Add project-scoped secrets page

### DIFF
--- a/src/api/hooks/secret.ts
+++ b/src/api/hooks/secret.ts
@@ -6,13 +6,18 @@ import { SecretType } from 'src/model';
 import { mapSecret } from '../mappers/secret';
 import { apiQuery } from '../query';
 
-export function useSecretsQuery(type?: SecretType) {
+type UseSecretsQueryOptions = {
+  projectId?: string;
+};
+
+export function useSecretsQuery(type?: SecretType, options: UseSecretsQueryOptions = {}) {
   const pagination = usePagination(100);
 
   const query = useQuery({
     ...apiQuery('get /v1/secrets', {
       query: {
         ...pagination.query,
+        project_id: options.projectId,
         types: type !== undefined ? [type] : undefined,
       },
     }),
@@ -28,6 +33,6 @@ export function useSecretsQuery(type?: SecretType) {
   return [query, pagination] as const;
 }
 
-export function useSecrets(type?: SecretType) {
-  return useSecretsQuery(type)[0].data?.secrets;
+export function useSecrets(type?: SecretType, options?: UseSecretsQueryOptions) {
+  return useSecretsQuery(type, options)[0].data?.secrets;
 }

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -1888,7 +1888,8 @@
         "/sandboxes/$serviceId/metrics": "Metrics",
         "/sandboxes/$serviceId/console": "Console",
         "/project/secrets": "Project secrets",
-        "/project/settings": "Project settings"
+        "/project/settings": "Project settings",
+        "/project/settings/": "Project settings"
       }
     },
     "secondary": {

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -2476,7 +2476,8 @@
       }
     },
     "secrets": {
-      "title": "Project Secrets",
+      "title": "Secrets",
+      "projectTitle": "Project Secrets",
       "createSecret": "Create secret",
       "deleteSecrets": "Delete selected ({count})",
       "importSecrets": "Import secrets",

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -2476,9 +2476,7 @@
       }
     },
     "secrets": {
-      "title": "Secrets",
-      "organizationTitle": "Organization Secrets",
-      "projectTitle": "Project Secrets",
+      "title": "Project Secrets",
       "createSecret": "Create secret",
       "deleteSecrets": "Delete selected ({count})",
       "importSecrets": "Import secrets",

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -1888,8 +1888,7 @@
         "/sandboxes/$serviceId/metrics": "Metrics",
         "/sandboxes/$serviceId/console": "Console",
         "/project/secrets": "Project secrets",
-        "/project/settings": "Project settings",
-        "/project/settings/": "Project settings"
+        "/project/settings": "Project settings"
       }
     },
     "secondary": {

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -1887,6 +1887,7 @@
         "/sandboxes": "Sandboxes",
         "/sandboxes/$serviceId/metrics": "Metrics",
         "/sandboxes/$serviceId/console": "Console",
+        "/project/secrets": "Project secrets",
         "/project/settings": "Project settings"
       }
     },
@@ -2476,6 +2477,8 @@
     },
     "secrets": {
       "title": "Secrets",
+      "organizationTitle": "Organization Secrets",
+      "projectTitle": "Project Secrets",
       "createSecret": "Create secret",
       "deleteSecrets": "Delete selected ({count})",
       "importSecrets": "Import secrets",

--- a/src/layouts/main/navigation.tsx
+++ b/src/layouts/main/navigation.tsx
@@ -69,6 +69,15 @@ export function Navigation({ collapsed }: { collapsed: boolean }) {
               label={<T id="domains" />}
               to="/domains"
             />
+
+            <NavigationItem
+              collapsed={collapsed}
+              disabled={disableComputeLinks}
+              Icon={IconFileKey}
+              label={<T id="secrets" />}
+              to="/secrets"
+            />
+
             <NavigationItem
               collapsed={collapsed}
               disabled={disableComputeLinks}

--- a/src/layouts/main/navigation.tsx
+++ b/src/layouts/main/navigation.tsx
@@ -69,15 +69,6 @@ export function Navigation({ collapsed }: { collapsed: boolean }) {
               label={<T id="domains" />}
               to="/domains"
             />
-
-            <NavigationItem
-              collapsed={collapsed}
-              disabled={disableComputeLinks}
-              Icon={IconFileKey}
-              label={<T id="secrets" />}
-              to="/secrets"
-            />
-
             <NavigationItem
               collapsed={collapsed}
               disabled={disableComputeLinks}
@@ -188,14 +179,6 @@ export function Navigation({ collapsed }: { collapsed: boolean }) {
         </div>
 
         <ol className="col gap-1 sm:gap-2">
-          <NavigationItem
-            collapsed={collapsed}
-            disabled={disableComputeLinks}
-            Icon={IconFileKey}
-            label={<T id="secrets" />}
-            to="/secrets"
-          />
-
           <NavigationItem collapsed={collapsed} Icon={IconUsers} label={<T id="team" />} to="/team" />
 
           <NavigationItem

--- a/src/layouts/main/navigation.tsx
+++ b/src/layouts/main/navigation.tsx
@@ -160,6 +160,14 @@ export function Navigation({ collapsed }: { collapsed: boolean }) {
 
           <NavigationItem
             collapsed={collapsed}
+            disabled={disableComputeLinks}
+            Icon={IconFileKey}
+            label={<T id="secrets" />}
+            to="/project/secrets"
+          />
+
+          <NavigationItem
+            collapsed={collapsed}
             Icon={IconActivity}
             label={<T id="activity" />}
             to="/activity"

--- a/src/modules/secrets/simple/create-secret-dialog.tsx
+++ b/src/modules/secrets/simple/create-secret-dialog.tsx
@@ -8,10 +8,11 @@ import { SecretForm } from 'src/modules/secrets/simple/simple-secret-form';
 const T = createTranslate('modules.secrets.simpleSecretForm');
 
 type CreateSecretDialogProps = {
+  projectId?: string;
   onCreated?: (secretName: string) => void;
 };
 
-export function CreateSecretDialog({ onCreated }: CreateSecretDialogProps) {
+export function CreateSecretDialog({ projectId, onCreated }: CreateSecretDialogProps) {
   const t = T.useTranslate();
 
   return (
@@ -23,6 +24,7 @@ export function CreateSecretDialog({ onCreated }: CreateSecretDialogProps) {
       </p>
 
       <SecretForm
+        projectId={projectId}
         renderFooter={(formState) => (
           <DialogFooter>
             <CloseDialogButton>

--- a/src/modules/secrets/simple/simple-secret-form.tsx
+++ b/src/modules/secrets/simple/simple-secret-form.tsx
@@ -24,11 +24,12 @@ const schema = z.object({
 
 type SecretFormProps = {
   secret?: Secret;
+  projectId?: string;
   renderFooter: (formState: FormState<FieldValues>) => React.ReactNode;
   onSubmitted: (secretName: string) => void;
 };
 
-export function SecretForm({ secret, renderFooter, onSubmitted }: SecretFormProps) {
+export function SecretForm({ secret, projectId, renderFooter, onSubmitted }: SecretFormProps) {
   const t = T.useTranslate();
 
   const api = useApi();
@@ -59,7 +60,11 @@ export function SecretForm({ secret, renderFooter, onSubmitted }: SecretFormProp
         });
       } else {
         return api('post /v1/secrets', {
-          body: { type: 'SIMPLE', ...param },
+          body: {
+            type: 'SIMPLE',
+            ...param,
+            ...(projectId !== undefined ? { project_id: projectId } : {}),
+          },
         });
       }
     },

--- a/src/pages/secrets/components/bulk-create-secrets-dialog.tsx
+++ b/src/pages/secrets/components/bulk-create-secrets-dialog.tsx
@@ -16,7 +16,12 @@ import { hasProperty } from 'src/utils/object';
 
 const T = createTranslate('pages.secrets.bulkCreate');
 
-export function BulkCreateSecretsDialog({ onCreated }: { onCreated?: () => void }) {
+type BulkCreateSecretsDialogProps = {
+  projectId?: string;
+  onCreated?: () => void;
+};
+
+export function BulkCreateSecretsDialog({ projectId, onCreated }: BulkCreateSecretsDialogProps) {
   const t = T.useTranslate();
 
   const api = useApi();
@@ -42,7 +47,14 @@ export function BulkCreateSecretsDialog({ onCreated }: { onCreated?: () => void 
 
       const results = await Promise.allSettled(
         Object.entries(values).map(([name, value]) =>
-          api('post /v1/secrets', { body: { type: 'SIMPLE', name, value } }),
+          api('post /v1/secrets', {
+            body: {
+              type: 'SIMPLE',
+              name,
+              value,
+              ...(projectId !== undefined ? { project_id: projectId } : {}),
+            },
+          }),
         ),
       );
 

--- a/src/pages/secrets/secrets.page.tsx
+++ b/src/pages/secrets/secrets.page.tsx
@@ -23,22 +23,15 @@ import { SecretsList } from './components/secrets-list';
 
 const T = createTranslate('pages.secrets');
 
-type SecretsPageProps = {
-  scope?: 'organization' | 'project';
-};
-
-export function SecretsPage({ scope = 'organization' }: SecretsPageProps) {
+export function SecretsPage() {
   const t = T.useTranslate();
   const [projectId] = useCurrentProjectId();
-  const projectScoped = scope === 'project';
-  const scopedProjectId = projectScoped ? projectId : undefined;
-  const titleId = projectScoped ? 'projectTitle' : 'organizationTitle';
 
   useOnRouteStateCreate(() => {
     openDialog('CreateSecret');
   });
 
-  const [query, pagination] = useSecretsQuery('SIMPLE', { projectId: scopedProjectId });
+  const [query, pagination] = useSecretsQuery('SIMPLE', { projectId });
   const secrets = query.data?.secrets;
 
   const [selected, { toggle, set, clear }] = useSet<Secret>();
@@ -62,10 +55,10 @@ export function SecretsPage({ scope = 'organization' }: SecretsPageProps) {
 
   return (
     <div className="col gap-8">
-      <DocumentTitle title={t(titleId)} />
+      <DocumentTitle title={t('title')} />
 
       <Title
-        title={<T id={titleId} />}
+        title={<T id="title" />}
         end={
           <div className="row items-center gap-2">
             {selected.size > 0 && (
@@ -103,8 +96,8 @@ export function SecretsPage({ scope = 'organization' }: SecretsPageProps) {
 
       {pagination.hasPages && <Pagination pagination={pagination} />}
 
-      <BulkCreateSecretsDialog projectId={scopedProjectId} onCreated={onChanged} />
-      <CreateSecretDialog projectId={scopedProjectId} onCreated={onChanged} />
+      <BulkCreateSecretsDialog projectId={projectId} onCreated={onChanged} />
+      <CreateSecretDialog projectId={projectId} onCreated={onChanged} />
       <EditSecretDialog />
     </div>
   );

--- a/src/pages/secrets/secrets.page.tsx
+++ b/src/pages/secrets/secrets.page.tsx
@@ -2,7 +2,8 @@ import { Button } from '@koyeb/design-system';
 import { useMutation } from '@tanstack/react-query';
 import clsx from 'clsx';
 
-import { useApi, useCurrentProjectId, useInvalidateApiQuery, useSecretsQuery } from 'src/api';
+import { useApi, useInvalidateApiQuery, useSecretsQuery } from 'src/api';
+import { useCurrentProjectId } from 'src/api/hooks/project';
 import { notify } from 'src/application/notify';
 import { closeDialog, openDialog } from 'src/components/dialog';
 import { DocumentTitle } from 'src/components/document-title';

--- a/src/pages/secrets/secrets.page.tsx
+++ b/src/pages/secrets/secrets.page.tsx
@@ -2,7 +2,7 @@ import { Button } from '@koyeb/design-system';
 import { useMutation } from '@tanstack/react-query';
 import clsx from 'clsx';
 
-import { useApi, useInvalidateApiQuery, useSecretsQuery } from 'src/api';
+import { useApi, useCurrentProjectId, useInvalidateApiQuery, useSecretsQuery } from 'src/api';
 import { notify } from 'src/application/notify';
 import { closeDialog, openDialog } from 'src/components/dialog';
 import { DocumentTitle } from 'src/components/document-title';
@@ -22,14 +22,22 @@ import { SecretsList } from './components/secrets-list';
 
 const T = createTranslate('pages.secrets');
 
-export function SecretsPage() {
+type SecretsPageProps = {
+  scope?: 'organization' | 'project';
+};
+
+export function SecretsPage({ scope = 'organization' }: SecretsPageProps) {
   const t = T.useTranslate();
+  const [projectId] = useCurrentProjectId();
+  const projectScoped = scope === 'project';
+  const scopedProjectId = projectScoped ? projectId : undefined;
+  const titleId = projectScoped ? 'projectTitle' : 'organizationTitle';
 
   useOnRouteStateCreate(() => {
     openDialog('CreateSecret');
   });
 
-  const [query, pagination] = useSecretsQuery('SIMPLE');
+  const [query, pagination] = useSecretsQuery('SIMPLE', { projectId: scopedProjectId });
   const secrets = query.data?.secrets;
 
   const [selected, { toggle, set, clear }] = useSet<Secret>();
@@ -53,10 +61,10 @@ export function SecretsPage() {
 
   return (
     <div className="col gap-8">
-      <DocumentTitle title="Secrets" />
+      <DocumentTitle title={t(titleId)} />
 
       <Title
-        title={<T id="title" />}
+        title={<T id={titleId} />}
         end={
           <div className="row items-center gap-2">
             {selected.size > 0 && (
@@ -94,8 +102,8 @@ export function SecretsPage() {
 
       {pagination.hasPages && <Pagination pagination={pagination} />}
 
-      <BulkCreateSecretsDialog onCreated={onChanged} />
-      <CreateSecretDialog onCreated={onChanged} />
+      <BulkCreateSecretsDialog projectId={scopedProjectId} onCreated={onChanged} />
+      <CreateSecretDialog projectId={scopedProjectId} onCreated={onChanged} />
       <EditSecretDialog />
     </div>
   );

--- a/src/pages/secrets/secrets.page.tsx
+++ b/src/pages/secrets/secrets.page.tsx
@@ -23,15 +23,22 @@ import { SecretsList } from './components/secrets-list';
 
 const T = createTranslate('pages.secrets');
 
-export function SecretsPage() {
+type SecretsPageProps = {
+  scope?: 'organization' | 'project';
+  title?: React.ReactNode;
+  documentTitle?: string;
+};
+
+export function SecretsPage({ scope = 'project', title, documentTitle }: SecretsPageProps) {
   const t = T.useTranslate();
   const [projectId] = useCurrentProjectId();
+  const scopedProjectId = scope === 'project' ? projectId : undefined;
 
   useOnRouteStateCreate(() => {
     openDialog('CreateSecret');
   });
 
-  const [query, pagination] = useSecretsQuery('SIMPLE', { projectId });
+  const [query, pagination] = useSecretsQuery('SIMPLE', { projectId: scopedProjectId });
   const secrets = query.data?.secrets;
 
   const [selected, { toggle, set, clear }] = useSet<Secret>();
@@ -55,10 +62,10 @@ export function SecretsPage() {
 
   return (
     <div className="col gap-8">
-      <DocumentTitle title={t('title')} />
+      <DocumentTitle title={documentTitle ?? t('title')} />
 
       <Title
-        title={<T id="title" />}
+        title={title ?? <T id="title" />}
         end={
           <div className="row items-center gap-2">
             {selected.size > 0 && (
@@ -96,8 +103,8 @@ export function SecretsPage() {
 
       {pagination.hasPages && <Pagination pagination={pagination} />}
 
-      <BulkCreateSecretsDialog projectId={projectId} onCreated={onChanged} />
-      <CreateSecretDialog projectId={projectId} onCreated={onChanged} />
+      <BulkCreateSecretsDialog projectId={scopedProjectId} onCreated={onChanged} />
+      <CreateSecretDialog projectId={scopedProjectId} onCreated={onChanged} />
       <EditSecretDialog />
     </div>
   );

--- a/src/route-tree.generated.ts
+++ b/src/route-tree.generated.ts
@@ -16,6 +16,7 @@ import { Route as AuthSignoutRouteImport } from './routes/auth/signout'
 import { Route as AuthSigninRouteImport } from './routes/auth/signin'
 import { Route as MainTeamRouteImport } from './routes/_main/team'
 import { Route as MainSecretsRouteImport } from './routes/_main/secrets'
+import { Route as MainProjectSecretsRouteImport } from './routes/_main/project.secrets'
 import { Route as MainDomainsRouteImport } from './routes/_main/domains'
 import { Route as MainDeployRouteImport } from './routes/_main/deploy'
 import { Route as MainActivityRouteImport } from './routes/_main/activity'
@@ -89,6 +90,11 @@ const AuthSigninRoute = AuthSigninRouteImport.update({
   id: '/auth/signin',
   path: '/auth/signin',
   getParentRoute: () => rootRouteImport,
+} as any)
+const MainProjectSecretsRoute = MainProjectSecretsRouteImport.update({
+  id: '/project/secrets',
+  path: '/project/secrets',
+  getParentRoute: () => MainRouteRoute,
 } as any)
 const MainTeamRoute = MainTeamRouteImport.update({
   id: '/team',
@@ -376,6 +382,7 @@ export interface FileRoutesByFullPath {
   '/deploy': typeof MainDeployRoute
   '/domains': typeof MainDomainsRoute
   '/secrets': typeof MainSecretsRoute
+  '/project/secrets': typeof MainProjectSecretsRoute
   '/team': typeof MainTeamRoute
   '/auth/signin': typeof AuthSigninRoute
   '/auth/signout': typeof AuthSignoutRoute
@@ -428,6 +435,7 @@ export interface FileRoutesByTo {
   '/deploy': typeof MainDeployRoute
   '/domains': typeof MainDomainsRoute
   '/secrets': typeof MainSecretsRoute
+  '/project/secrets': typeof MainProjectSecretsRoute
   '/team': typeof MainTeamRoute
   '/auth/signin': typeof AuthSigninRoute
   '/auth/signout': typeof AuthSignoutRoute
@@ -482,6 +490,7 @@ export interface FileRoutesById {
   '/_main/deploy': typeof MainDeployRoute
   '/_main/domains': typeof MainDomainsRoute
   '/_main/secrets': typeof MainSecretsRoute
+  '/_main/project/secrets': typeof MainProjectSecretsRoute
   '/_main/team': typeof MainTeamRoute
   '/auth/signin': typeof AuthSigninRoute
   '/auth/signout': typeof AuthSignoutRoute
@@ -542,6 +551,7 @@ export interface FileRouteTypes {
     | '/deploy'
     | '/domains'
     | '/secrets'
+    | '/project/secrets'
     | '/team'
     | '/auth/signin'
     | '/auth/signout'
@@ -594,6 +604,7 @@ export interface FileRouteTypes {
     | '/deploy'
     | '/domains'
     | '/secrets'
+    | '/project/secrets'
     | '/team'
     | '/auth/signin'
     | '/auth/signout'
@@ -647,6 +658,7 @@ export interface FileRouteTypes {
     | '/_main/deploy'
     | '/_main/domains'
     | '/_main/secrets'
+    | '/_main/project/secrets'
     | '/_main/team'
     | '/auth/signin'
     | '/auth/signout'
@@ -756,6 +768,13 @@ declare module '@tanstack/react-router' {
       path: '/secrets'
       fullPath: '/secrets'
       preLoaderRoute: typeof MainSecretsRouteImport
+      parentRoute: typeof MainRouteRoute
+    }
+    '/_main/project/secrets': {
+      id: '/_main/project/secrets'
+      path: '/project/secrets'
+      fullPath: '/project/secrets'
+      preLoaderRoute: typeof MainProjectSecretsRouteImport
       parentRoute: typeof MainRouteRoute
     }
     '/_main/domains': {
@@ -1270,6 +1289,7 @@ interface MainRouteRouteChildren {
   MainDeployRoute: typeof MainDeployRoute
   MainDomainsRoute: typeof MainDomainsRoute
   MainSecretsRoute: typeof MainSecretsRoute
+  MainProjectSecretsRoute: typeof MainProjectSecretsRoute
   MainTeamRoute: typeof MainTeamRoute
   MainIndexRoute: typeof MainIndexRoute
   MainDatabaseServicesDatabaseServiceIdRouteRoute: typeof MainDatabaseServicesDatabaseServiceIdRouteRouteWithChildren
@@ -1293,6 +1313,7 @@ const MainRouteRouteChildren: MainRouteRouteChildren = {
   MainDeployRoute: MainDeployRoute,
   MainDomainsRoute: MainDomainsRoute,
   MainSecretsRoute: MainSecretsRoute,
+  MainProjectSecretsRoute: MainProjectSecretsRoute,
   MainTeamRoute: MainTeamRoute,
   MainIndexRoute: MainIndexRoute,
   MainDatabaseServicesDatabaseServiceIdRouteRoute:

--- a/src/routes/_main/project.secrets.tsx
+++ b/src/routes/_main/project.secrets.tsx
@@ -18,7 +18,7 @@ function RouteComponent() {
 
   return (
     <FeatureFlag feature="simple-projects">
-      <SecretsPage key={projectId} scope="project" />
+      <SecretsPage key={projectId} />
     </FeatureFlag>
   );
 }

--- a/src/routes/_main/project.secrets.tsx
+++ b/src/routes/_main/project.secrets.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router';
 
+import { useCurrentProjectId } from 'src/api/hooks/project';
 import { FeatureFlag } from 'src/hooks/feature-flag';
 import { CrumbLink } from 'src/layouts/main/app-breadcrumbs';
 import { SecretsPage } from 'src/pages/secrets/secrets.page';
@@ -13,9 +14,11 @@ export const Route = createFileRoute('/_main/project/secrets')({
 });
 
 function RouteComponent() {
+  const [projectId] = useCurrentProjectId();
+
   return (
     <FeatureFlag feature="simple-projects">
-      <SecretsPage scope="project" />
+      <SecretsPage key={projectId} scope="project" />
     </FeatureFlag>
   );
 }

--- a/src/routes/_main/project.secrets.tsx
+++ b/src/routes/_main/project.secrets.tsx
@@ -2,8 +2,11 @@ import { createFileRoute } from '@tanstack/react-router';
 
 import { useCurrentProjectId } from 'src/api/hooks/project';
 import { FeatureFlag } from 'src/hooks/feature-flag';
+import { createTranslate } from 'src/intl/translate';
 import { CrumbLink } from 'src/layouts/main/app-breadcrumbs';
 import { SecretsPage } from 'src/pages/secrets/secrets.page';
+
+const T = createTranslate('pages.secrets');
 
 export const Route = createFileRoute('/_main/project/secrets')({
   component: RouteComponent,
@@ -14,11 +17,12 @@ export const Route = createFileRoute('/_main/project/secrets')({
 });
 
 function RouteComponent() {
+  const t = T.useTranslate();
   const [projectId] = useCurrentProjectId();
 
   return (
     <FeatureFlag feature="simple-projects">
-      <SecretsPage key={projectId} />
+      <SecretsPage key={projectId} title={<T id="projectTitle" />} documentTitle={t('projectTitle')} />
     </FeatureFlag>
   );
 }

--- a/src/routes/_main/project.secrets.tsx
+++ b/src/routes/_main/project.secrets.tsx
@@ -1,0 +1,21 @@
+import { createFileRoute } from '@tanstack/react-router';
+
+import { FeatureFlag } from 'src/hooks/feature-flag';
+import { CrumbLink } from 'src/layouts/main/app-breadcrumbs';
+import { SecretsPage } from 'src/pages/secrets/secrets.page';
+
+export const Route = createFileRoute('/_main/project/secrets')({
+  component: RouteComponent,
+
+  beforeLoad: () => ({
+    breadcrumb: () => <CrumbLink to={Route.to} />,
+  }),
+});
+
+function RouteComponent() {
+  return (
+    <FeatureFlag feature="simple-projects">
+      <SecretsPage scope="project" />
+    </FeatureFlag>
+  );
+}

--- a/src/routes/_main/project.settings/index.tsx
+++ b/src/routes/_main/project.settings/index.tsx
@@ -13,7 +13,7 @@ export const Route = createFileRoute('/_main/project/settings/')({
   component: RouteComponent,
 
   beforeLoad: () => ({
-    breadcrumb: () => <CrumbLink to={Route.to} />,
+    breadcrumb: () => <CrumbLink to="/project/settings" />,
   }),
 });
 

--- a/src/routes/_main/secrets.tsx
+++ b/src/routes/_main/secrets.tsx
@@ -1,7 +1,21 @@
-import { createFileRoute, redirect } from '@tanstack/react-router';
+import { createFileRoute } from '@tanstack/react-router';
+
+import { FeatureFlag } from 'src/hooks/feature-flag';
+import { CrumbLink } from 'src/layouts/main/app-breadcrumbs';
+import { SecretsPage } from 'src/pages/secrets/secrets.page';
 
 export const Route = createFileRoute('/_main/secrets')({
-  beforeLoad: () => {
-    throw redirect({ to: '/project/secrets' });
-  },
+  component: RouteComponent,
+
+  beforeLoad: () => ({
+    breadcrumb: () => <CrumbLink to={Route.to} />,
+  }),
 });
+
+function RouteComponent() {
+  return (
+    <FeatureFlag feature="simple-projects" fallback={<SecretsPage scope="organization" />}>
+      {null}
+    </FeatureFlag>
+  );
+}

--- a/src/routes/_main/secrets.tsx
+++ b/src/routes/_main/secrets.tsx
@@ -1,12 +1,7 @@
-import { createFileRoute } from '@tanstack/react-router';
-
-import { CrumbLink } from 'src/layouts/main/app-breadcrumbs';
-import { SecretsPage } from 'src/pages/secrets/secrets.page';
+import { createFileRoute, redirect } from '@tanstack/react-router';
 
 export const Route = createFileRoute('/_main/secrets')({
-  component: SecretsPage,
-
-  beforeLoad: () => ({
-    breadcrumb: () => <CrumbLink to={Route.to} />,
-  }),
+  beforeLoad: () => {
+    throw redirect({ to: '/project/secrets' });
+  },
 });


### PR DESCRIPTION
## Summary
- add a project-scoped secrets page at `/project/secrets`
- make the project secrets page list/create secrets with the current `project_id`
- keep `/secrets` as the legacy organization secrets page only for users without `simple-projects`
- keep secrets navigation at `/secrets` in the legacy nav and show `/project/secrets` in the simple-projects nav
- use canonical `/project/settings` for the project settings breadcrumb

## Verification
- `python3 -m json.tool src/intl/en.json`
- `git diff --check`
- GitHub CI on the PR
