### PR TITLE
[KOYEB-5954] Fix projectId caching

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -3,6 +3,7 @@ import { OmitBy, ValueOf } from 'src/utils/types';
 
 import { ApiError } from './api-error';
 import { paths } from './api.generated';
+import { getCurrentProjectId } from './current-project-id';
 
 export type ApiEndpoint = Compute<
   ValueOf<{
@@ -49,6 +50,15 @@ export async function api<E extends ApiEndpoint>(
   if ('body' in params) {
     headers.set('Content-Type', 'application/json');
     init.body = JSON.stringify(params.body);
+  }
+
+  // Every request is scoped to the currently selected project, so source the
+  // project id from the global store rather than the request payload. An explicit
+  // x-koyeb-project-id header (set above) always takes precedence.
+  const projectId = getCurrentProjectId();
+
+  if (projectId !== null && !headers.has('x-koyeb-project-id')) {
+    headers.set('x-koyeb-project-id', projectId);
   }
 
   if (token) {

--- a/src/api/current-project-id.ts
+++ b/src/api/current-project-id.ts
@@ -1,0 +1,12 @@
+import { StoredValue } from 'src/application/storage';
+
+// Globally stored id of the project the user is currently working in. Kept in a
+// dedicated module (free of API dependencies) so it can be read both from React
+// hooks and from the low-level `api` function without creating an import cycle.
+export const storedCurrentProjectId = new StoredValue<string>('currentProjectId', {
+  parse: String,
+  stringify: String,
+});
+
+export const getCurrentProjectId = storedCurrentProjectId.read;
+export const setCurrentProjectId = storedCurrentProjectId.write;

--- a/src/api/hooks/project.ts
+++ b/src/api/hooks/project.ts
@@ -1,11 +1,13 @@
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { useSyncExternalStore } from 'react';
 
-import { StoredValue } from 'src/application/storage';
 import { Project } from 'src/model';
 import { requiredDeep, snakeToCamelDeep } from 'src/utils/object';
 
+import { getCurrentProjectId, setCurrentProjectId, storedCurrentProjectId } from '../current-project-id';
 import { apiQuery } from '../query';
+
+export { getCurrentProjectId, setCurrentProjectId };
 
 export function useProjectsQuery({ search, limit }: Partial<{ search: string; limit: number }> = {}) {
   return useQuery({
@@ -35,14 +37,6 @@ export function useProjectQuery(projectId?: string) {
 export function useProject(projectId?: string) {
   return useProjectQuery(projectId).data;
 }
-
-const storedCurrentProjectId = new StoredValue<string>('currentProjectId', {
-  parse: String,
-  stringify: String,
-});
-
-export const getCurrentProjectId = storedCurrentProjectId.read;
-export const setCurrentProjectId = storedCurrentProjectId.write;
 
 export function useCurrentProjectId(): [string | undefined, (projectId: string) => void] {
   const projectId = useSyncExternalStore(storedCurrentProjectId.listen, storedCurrentProjectId.read);

--- a/src/routes/_main/route.tsx
+++ b/src/routes/_main/route.tsx
@@ -51,22 +51,21 @@ export const Route = createFileRoute('/_main')({
     let projectId = getCurrentProjectId() ?? undefined;
 
     if (organization !== undefined) {
-      if (projectId === undefined) {
+      // The current project id is persisted across reloads and organization
+      // switches (including silent ones done through the WorkOS widgets). Make
+      // sure it still points to a project that belongs to the active
+      // organization, otherwise reset it to the organization's default project.
+      // Without this, a stale id would be sent as the x-koyeb-project-id header
+      // on every request and rejected by the API.
+      if (
+        projectId === undefined ||
+        !(await projectBelongsToOrganization(ensureApiQueryData, projectId, organization.id))
+      ) {
         projectId = organization.defaultProjectId;
         setCurrentProjectId(projectId);
       }
 
-      try {
-        await ensureApiQueryData('get /v1/projects/{id}', { path: { id: projectId } });
-      } catch (error) {
-        if (ApiError.is(error, 404)) {
-          projectId = organization.defaultProjectId;
-          setCurrentProjectId(projectId);
-          await ensureApiQueryData('get /v1/projects/{id}', { path: { id: projectId } });
-        } else {
-          throw error;
-        }
-      }
+      await ensureApiQueryData('get /v1/projects/{id}', { path: { id: projectId } });
     }
 
     void identifyUserInIntercom(api, user);
@@ -142,6 +141,23 @@ export const Route = createFileRoute('/_main')({
     await Promise.all(promises);
   },
 });
+
+async function projectBelongsToOrganization(
+  ensureApiQueryData: ReturnType<typeof createEnsureApiQueryData>,
+  projectId: string,
+  organizationId: string,
+) {
+  try {
+    const { project } = await ensureApiQueryData('get /v1/projects/{id}', { path: { id: projectId } });
+    return project?.organization_id === organizationId;
+  } catch (error) {
+    if (ApiError.is(error, 404)) {
+      return false;
+    }
+
+    throw error;
+  }
+}
 
 async function switchOrganization(authKit: AuthKit, externalId: string) {
   await authKit.switchToOrganization({ organizationId: externalId });


### PR DESCRIPTION
When switching organizations, the old `currentProjectId` was cached without being invalidated and all requests bore the old (invalid) `x-koyeb-project-id`.
This PR fixes cache invalidation.